### PR TITLE
screen utilを導入

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,31 +8,21 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    return ScreenUtilInit(
+      designSize: const Size(411, 960), // Sony Xperia 1 II
+      builder: (_, child) {
+        return MaterialApp(
+          title: 'Search Repository',
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+            useMaterial3: true,
+          ),
+          home: child,
+        );
+      },
+      child: const MyHomePage(title: 'Search Repository'),
     );
   }
 }

--- a/lib/test_widget.dart
+++ b/lib/test_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
@@ -8,8 +9,8 @@ class TestWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 100,
-      height: 100,
+      width: 100.r,
+      height: 100.r,
       color: Colors.red,
     );
   }

--- a/lib/widgetbook.dart
+++ b/lib/widgetbook.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
@@ -41,6 +42,16 @@ class WidgetbookApp extends StatelessWidget {
           scales: <double>[1.0, 2.0],
         ),
         InspectorAddon(),
+        BuilderAddon(
+          name: 'ScreenUtil',
+          builder: (context, child) {
+            return ScreenUtilInit(
+              designSize: const Size(411, 960), // Sony Xperia 1 II
+              builder: (context, child) => child!,
+              child: child,
+            );
+          },
+        )
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -227,6 +227,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_screenutil:
+    dependency: "direct main"
+    description:
+      name: flutter_screenutil
+      sha256: "8239210dd68bee6b0577aa4a090890342d04a136ce1c81f98ee513fc0ce891de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_screenutil: ^5.9.3
   widgetbook: ^3.8.1
   widgetbook_annotation: ^3.1.0
 


### PR DESCRIPTION
## Issue

close #5 

## 対応箇所

- [x] screen utilを導入
- [x] widget bookとscreen utilの組み合わせ

## 動作確認
![image](https://github.com/user-attachments/assets/1e60a1f5-e475-49d1-bfe3-48906ffd2d60)
![image](https://github.com/user-attachments/assets/8abe426c-51bb-4be7-86ce-87553e0d37ef)

※screen utilの幅はchromeの幅に依存してしまう（runAppを呼び出した場所のbindingを参照する）ため、widget bookで確認するとややレイアウトが崩れて見える。幅指定の際に.hではなく.rを使うことで少し改善する。
